### PR TITLE
fix comments so that all .v files can be run through vfmt

### DIFF
--- a/repo.v
+++ b/repo.v
@@ -39,9 +39,10 @@ mut:
 	msg_cache          map[string]string [skip]
 }
 
+// log_field_separator is declared as constant in case we need to change it later
 const (
 	max_git_res_size = 1000
-	log_field_separator = '\x7F' // declared as constant in case we need to change it later
+	log_field_separator = '\x7F'
 )
 
 enum RepoStatus {

--- a/repo_db.v
+++ b/repo_db.v
@@ -21,8 +21,9 @@ fn (mut app App) create_tables() {
 		'nr_open_prs int default 0'
 		'nr_branches int default 0'
 		'nr_contributors int default 0'
-		"created_at int default (strftime('%s', 'now'))" // unix time default now
+		"created_at int default (strftime('%s', 'now'))" 
 	])
+    // unix time default now
 	app.create_table('File', [
 		'id integer primary key'
 		"name text default ''"
@@ -37,8 +38,8 @@ fn (mut app App) create_tables() {
 		'nr_contributors int default 0'
 		'nr_views int default 0'
 		'UNIQUE(parent_path, name, repo_id) ON CONFLICT REPLACE'
-		//"created_at int default (strftime('%s', 'now'))"
 	])
+	//"created_at int default (strftime('%s', 'now'))"
 	app.create_table('Issue', [
 		'id integer primary key'
 		'author_id int default 0'
@@ -47,18 +48,19 @@ fn (mut app App) create_tables() {
 		"title text default ''"
 		"text text default ''"
 		'nr_comments int default 0'
-		//"created_at int default (strftime('%s', 'now'))"
 	])
+	//		"created_at int default (strftime('%s', 'now'))"
 	app.create_table('Commit', [
 		'id integer primary key'
 		'author_id int default 0'
-		"author text default ''" // to avoid joins
+		"author text default ''"
 		"hash text default ''"
 		'repo_id int default 0'
 		"message text default ''"
 		"created_at int default (strftime('%s', 'now'))"
 		'UNIQUE(hash)'
 	])
+	// author text default '' is to to avoid joins
 	app.create_table('LangStat', [
 		'id int default 0'
 		'repo_id int default 0'


### PR DESCRIPTION
This PR makes it possible to run `v fmt` over all .v files. 
It simply moves some of the comments outside 'dangerous' areas, where vfmt currently can not handle them properly.