### PR TITLE
unify layout for branches

### DIFF
--- a/gitly.v
+++ b/gitly.v
@@ -182,6 +182,9 @@ pub fn (mut app App) create_new_test_repo() {
 		app.info('test repo already exists')
 		app.repo = x
 		app.repo.lang_stats = app.find_lang_stats_by_repo_id(app.repo.id)
+		// init branches list for existing repo
+		mut r := &app.repo
+		r.branches = get_branches(r)
 		return
 	}
 	_ := os.ls('.') or {

--- a/static/css/branches.scss
+++ b/static/css/branches.scss
@@ -1,5 +1,5 @@
 div.branches{
-    div.branch:first-child {
-        border-top: 1px solid #dfdfdf;
-  }
+	div.branch:first-child {
+		border-top: 1px solid #dfdfdf;
+	}
 }

--- a/static/css/branches.scss
+++ b/static/css/branches.scss
@@ -1,0 +1,5 @@
+div.branches{
+    div.branch:first-child {
+        border-top: 1px solid #dfdfdf;
+  }
+}

--- a/static/css/gitly.scss
+++ b/static/css/gitly.scss
@@ -70,4 +70,4 @@ h3 {
 	float: left;
 }
 
-@import 'files', 'langs', 'tree', 'commits', 'hl_table';
+@import 'files', 'langs', 'tree', 'commits', 'hl_table', 'branches';

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -793,7 +793,7 @@ img.clog-avatar {
 	padding-bottom:5px;
 }
 .clog-author {
-	a {
+	a, span {
 		font-weight: bold;
 		font-size: 11px;
 		color: $gray-dark !important;

--- a/templates/branches.html
+++ b/templates/branches.html
@@ -1,19 +1,19 @@
 @header
-<style>
-.branch_name {
-    font-family:Roboto-Mono, Menlo;
-    background-color:rgb(230, 247, 253);
-    color:blue;
-    padding:4px;
-    line-height:200%
-}
-</style>
 <h3>Branches</h3>
-
 .branches {
     @for branch in branches
         .branch {
-            <span class='branch_name'>@branch.name</span>&nbsp;&nbsp;Updated @branch.date.relative() by @branch.author
+            .clog {
+                .clog-msg {
+                    <a href='/branch/@branch.name'>@branch.name</a>
+                }
+                span.clog-author {
+                    <span >@branch.author</span>
+                }
+                span.clog-time {
+                    updated @branch.date.relative()
+                }
+            }
         }
     @end
 }

--- a/templates/branches.html
+++ b/templates/branches.html
@@ -5,7 +5,7 @@
         .branch {
             .clog {
                 .clog-msg {
-                    <a href='/branch/@branch.name'>@branch.name</a>
+                    <a href='/branches/'>@branch.name</a>
                 }
                 span.clog-author {
                     <span >@branch.author</span>

--- a/templates/branches.html
+++ b/templates/branches.html
@@ -1,19 +1,19 @@
 @header
 <h3>Branches</h3>
 .branches {
-    @for branch in branches
-        .branch {
-            .clog {
-                .clog-msg {
-                    <a href='/branches/'>@branch.name</a>
-                }
-                span.clog-author {
-                    <span >@branch.author</span>
-                }
-                span.clog-time {
-                    updated @branch.date.relative()
-                }
-            }
-        }
-    @end
+	@for branch in branches
+		.branch {
+			.clog {
+				.clog-msg {
+					<a href='/branches/'>@branch.name</a>
+				}
+				span.clog-author {
+					<span >@branch.author</span>
+				}
+				span.clog-time {
+					updated @branch.date.relative()
+				}
+			}
+		}
+	@end
 }


### PR DESCRIPTION
I changed the layout for the branches page to match the exiting ones.
Since the branches list was not initialized when the 'test repo already exists' I also added that.