### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.12
 
 LABEL maintainer="shiipou <shiishii@nocturlab.fr>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM alpine:3.11
+
+LABEL maintainer="shiipou <shiishii@nocturlab.fr>"
+
+ENV V_HOME /opt/v
+ENV GITLY_HOME /opt/gitly
+
+WORKDIR ${V_HOME}
+
+ENV PATH ${PATH}:/opt/vlang
+
+RUN mkdir -p ${V_HOME}
+
+RUN apk --no-cache add \
+  git make upx gcc \
+  musl-dev \
+  openssl-dev sqlite-dev \
+  libx11-dev glfw-dev freetype-dev \
+  sassc
+
+RUN apk --no-cache add --virtual sdl2deps sdl2-dev sdl2_ttf-dev sdl2_mixer-dev sdl2_image-dev
+
+RUN git clone https://github.com/vlang/v ${V_HOME} \
+ && make \
+ && ${V_HOME}/v symlink \
+ && v version
+
+WORKDIR ${GITLY_HOME}
+
+COPY . ${GITLY_HOME}
+
+RUN sassc ${GITLY_HOME}/static/css/gitly.scss > ${GITLY_HOME}/static/css/gitly.css \
+ && v .
+
+CMD ${GITLY_HOME}/gitly


### PR DESCRIPTION
This make easly to deploy gitly on any kubernetes or docker swarm cluster.

I suggest to publish an official V image at https://hub.docker.com/r/vlang/v to make this Dockerfile smaller.

(just an `FROM vlang/v` at the start remove so many lines)

You can host it on GitHub in the package area if you think it better.