### PR TITLE
Fix repo author/name styling on header

### DIFF
--- a/static/css/gitly.scss
+++ b/static/css/gitly.scss
@@ -169,6 +169,20 @@ pre > code {
 	color: $white;
 	line-height: 50px;
 }
+
+#header a {
+	line-height: 50px;
+	font-size: 20px !important;
+	color: $white;
+}
+
+#header .slash {
+	display: inline;
+	line-height: 50px;
+	font-size: 20px !important;
+	color: $white;
+}
+
 #header {
 	background-color: $black;
 	height: $header-height;

--- a/static/css/gitly.scss
+++ b/static/css/gitly.scss
@@ -161,7 +161,13 @@ pre > code {
 	position: absolute;
 	top: 0;
 	right: 0;
-	padding-right: 150px;
+	padding-right: 75px;
+}
+
+.new a {
+	line-height: 50px;
+	font-size: 16px !important;
+	color: $white;
 }
 
 
@@ -170,16 +176,17 @@ pre > code {
 	line-height: 50px;
 }
 
-#header a {
+
+#header a.repo-author, #header a.repo-name {
 	line-height: 50px;
-	font-size: 20px !important;
+	font-size: 16px !important;
 	color: $white;
 }
 
 #header .slash {
 	display: inline;
 	line-height: 50px;
-	font-size: 20px !important;
+	font-size: 16px !important;
 	color: $white;
 }
 

--- a/templates/header.html
+++ b/templates/header.html
@@ -34,7 +34,7 @@
 			<!--
 			<a href='https://gitly.org/@app.repo.user_name'>@app.repo.user_name</a> /
 			-->
-			<a href='/@app.repo.user_name'>@app.repo.user_name</a> /
+			<a href='/@app.repo.user_name'>@app.repo.user_name</a> <p class="slash">/</p>
 		@end
 		<!--
 		<a href='/@app.repo.user_name/@app.repo.name'>@app.repo.name</a>

--- a/templates/header.html
+++ b/templates/header.html
@@ -34,12 +34,12 @@
 			<!--
 			<a href='https://gitly.org/@app.repo.user_name'>@app.repo.user_name</a> /
 			-->
-			<a href='/@app.repo.user_name'>@app.repo.user_name</a> <p class="slash">/</p>
+			<a class="repo-author" href='/@app.repo.user_name'>@app.repo.user_name</a> <p class="slash">/</p>
 		@end
 		<!--
 		<a href='/@app.repo.user_name/@app.repo.name'>@app.repo.name</a>
 		-->
-		<a href='/@app.repo.user_name/@app.repo.name'>@app.repo.name</a>
+		<a class="repo-name" href='/@app.repo.user_name/@app.repo.name'>@app.repo.name</a>
 		@end
 	}
 	@if app.logged_in


### PR DESCRIPTION
This fixes the styling of the username / repo on the header to match with [the screenshot on the Gitly homepage.](https://user-images.githubusercontent.com/687996/85933714-b195fe80-b8da-11ea-9ddd-09cadc2103e4.png). This also changes the font size of the "new repo" text and repositions it to not be as far away from the user picture.

Before: 
![image](https://user-images.githubusercontent.com/5272976/102019783-5601e500-3d43-11eb-99ea-0384a995b633.png)

After:
![image](https://user-images.githubusercontent.com/5272976/102019786-5b5f2f80-3d43-11eb-891c-82e9976064cb.png)

