### PR TITLE
hl: fix duplicate of a const name `langs`

### DIFF
--- a/hl/langs.v
+++ b/hl/langs.v
@@ -39,13 +39,13 @@ pub fn extension_to_lang(ext string) ?Lang {
 }
 
 fn init_langs() []Lang {
-	mut langs := []Lang{cap:10}
-	langs << init_c()
-	langs << init_v()
-	langs << init_js()
-	langs << init_go()
-	langs << init_cpp()
-	langs << init_py()
-	langs << init_ts()
-	return langs
+	mut langs_ := []Lang{cap:10}
+	langs_ << init_c()
+	langs_ << init_v()
+	langs_ << init_js()
+	langs_ << init_go()
+	langs_ << init_cpp()
+	langs_ << init_py()
+	langs_ << init_ts()
+	return langs_
 }


### PR DESCRIPTION
This PR fixes duplicate of a const name `langs`.

```v
hl/langs.v:42:6: error: duplicate of a const name `langs`
   40 | 
   41 | fn init_langs() []Lang {
   42 |     mut langs := []Lang{cap:10}
      |         ~~~~~
   43 |     langs << init_c()
   44 |     langs << init_v()
```