### PR TITLE
fix compilation after Time.unix becomes i64

### DIFF
--- a/gitly.v
+++ b/gitly.v
@@ -29,7 +29,7 @@ struct App {
 pub mut:
 	db sqlite.DB
 mut:
-	started_at    u64
+	started_at    i64
 	path          string // current path being viewed
 	repo          Repo
 	version       string

--- a/repo.v
+++ b/repo.v
@@ -121,7 +121,7 @@ fn (mut app App) update_repo() {
 
 // update_repo updated the repo in the db
 fn (mut app App) update_repo_data(mut r Repo) {
-	last_commit := app.find_repo_last_commit(r.id)
+	//	last_commit := app.find_repo_last_commit(r.id)
 	r.git('fetch --all')
 	r.git('pull --all')
 	mut wg := sync.new_waitgroup()

--- a/tag.v
+++ b/tag.v
@@ -38,7 +38,7 @@ fn (mut app App) init_tags(mut r Repo) {
 			eprintln('Error: $err')
 			return
 		}
-		tag.date = date.unix_time()
+		tag.date = int(date.unix_time())
 		app.insert_tag(tag)
 		r.nr_tags++
 	}


### PR DESCRIPTION
This is needed to fix compilation after the field Time.unix becomes i64 .

The V PR for that change is: https://github.com/vlang/v/pull/11050