### PR TITLE
use new `//V_TEMPLATE` syntax for explicitly interpolating inside <script> tags

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -7,15 +7,15 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel='icon' type='image/svg+xml' href='/favicon.svg' sizes='any'>
 	<script>
-		var repoName = '@app.repo.name'
-		var branch = '@app.repo.primary_branch'
-		var path = '@app.path'
+		var repoName = '@app.repo.name'; //V_TEMPLATE
+		var branch = '@app.repo.primary_branch' //V_TEMPLATE
+		var path = '@app.path' //V_TEMPLATE
 		//var isTopFiles = {{.IsTopFiles}}
 
-		var fetchurl = '/@app.repo.name/tree-data?branch=@app.repo.primary_branch&path=@app.path'
+		var fetchurl = '/@app.repo.name/tree-data?branch=@app.repo.primary_branch&path=@app.path';//V_TEMPLATE
 
-		var sshUrl = 'ssh://git&#64;gitly.org/@app.repo.user_name/@app.repo.name'
-		var httpsUrl = 'https://@app.repo.user_name&#64;gitly.org/@app.repo.name'
+		var sshUrl = 'ssh://git&#64;gitly.org/@app.repo.user_name/@app.repo.name'; //V_TEMPLATE
+		var httpsUrl = 'https://@app.repo.user_name&#64;gitly.org/@app.repo.name'; //V_TEMPLATE
 	</script>
 
 	@if app.is_tree


### PR DESCRIPTION
Previously V's templates interpolated @ inside <script> tags by default, which caused various issues, since @ is also used in JavaScript .

Now, inside <script> tags, @ are not interpolated by default (after V a73e146).

Instead, the user has to explicitly mark JS lines, where the interpolation should happen with `//V_TEMPLATE`.
