### PR TITLE
ci: err.msg -> err.msg() (fix compilation with V PR#14013)

### DIFF
--- a/branch.v
+++ b/branch.v
@@ -25,7 +25,7 @@ fn (mut app App) fetch_branches(r Repo) {
 			branch.repo_id = r.id
 			branch.name = temp_branch.after('origin/')
 			hash_data := os.read_lines('$r.git_dir/.git/refs/heads/$branch.name') or {
-				app.info(err.msg)
+				app.info(err.msg())
 				return
 			}
 			branch.hash = hash_data[0].substr(0, 7)

--- a/oauth.v
+++ b/oauth.v
@@ -46,17 +46,17 @@ pub fn (mut app App) oauth() vweb.Result {
 	}
 	d := json.encode(req)
 	resp := http.post_json('https://github.com/login/oauth/access_token', d) or {
-		app.info(err.msg)
+		app.info(err.msg())
 		return app.r_home()
 	}
 	mut token := resp.text.find_between('access_token=', '&')
 	mut request := http.new_request(.get, 'https://api.github.com/user', '') or {
-		app.info(err.msg)
+		app.info(err.msg())
 		return app.r_home()
 	}
 	request.add_header(.authorization, 'token $token')
 	user_js := request.do() or {
-		app.info(err.msg)
+		app.info(err.msg())
 		return app.r_home()
 	}
 	if user_js.status_code != 200 {


### PR DESCRIPTION
The old err.msg syntax was deprecated in February.
This PR fixes the deprecation notices, and enables
compilation after PR#14013, which will make the old
syntax a hard error.