### PR TITLE
Added: of keyword in JS hightlight

### DIFF
--- a/highlight/javascript.v
+++ b/highlight/javascript.v
@@ -34,6 +34,7 @@ fn init_js() Lang {
 			'throw',
 			'delete',
 			'in',
+			'of',
 			'try',
 			'as',
 			'let',


### PR DESCRIPTION
Just noticed, this missing `of` keyword
For about on [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of)