### PR TITLE
fix url for manual css copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ v .
 If you don't want to install `sassc`, you can simply run
 
 ```
-curl https://gitly.org/gitly.css --output static/css/gitly.css
+curl https://gitly.org/css/gitly.css --output static/css/gitly.css
 ```
 
 


### PR DESCRIPTION
before (404): `https://gitly.org/gitly.css`

after: `https://gitly.org/css/gitly.css`