### PR TITLE
highlight: add support for lua

### DIFF
--- a/highlight/langs.v
+++ b/highlight/langs.v
@@ -41,7 +41,7 @@ fn init_langs() []Lang {
 	langs_ << init_c()
 	langs_ << init_v()
 	langs_ << init_js()
-  langs_ << init_lua()
+	langs_ << init_lua()
 	langs_ << init_go()
 	langs_ << init_cpp()
 	langs_ << init_d()

--- a/highlight/langs.v
+++ b/highlight/langs.v
@@ -41,6 +41,7 @@ fn init_langs() []Lang {
 	langs_ << init_c()
 	langs_ << init_v()
 	langs_ << init_js()
+  langs_ << init_lua()
 	langs_ << init_go()
 	langs_ << init_cpp()
 	langs_ << init_d()

--- a/highlight/lua.v
+++ b/highlight/lua.v
@@ -1,0 +1,36 @@
+module highlight
+
+fn init_lua() Lang {
+	return Lang{
+		name: 'Lua'
+    lang_extensions: ['lua']
+		line_comments: '--'
+    mline_comments: ['--[[', ']]']
+		string_start: ['"', "'"]
+		color: '#00007d'
+		keywords: [
+      'and',
+      'break',
+      'do',
+      'else',
+      'elseif',
+      'end',
+      'false',
+      'for',
+      'function',
+      'goto',
+      'if',
+      'in',
+      'local',
+      'nil',
+      'not',
+      'or',
+      'repeat',
+      'return',
+      'then',
+      'true',
+      'until',
+      'while',
+		]
+	}
+}


### PR DESCRIPTION
This patch adds syntax/highlight support for the [Lua](https://www.lua.org/) programming language.
Cheers.
