### PR TITLE
compilation errors V 0.4 fix

### DIFF
--- a/src/gitly.v
+++ b/src/gitly.v
@@ -244,7 +244,7 @@ fn (mut ctx Context) json_error(message string) veb.Result {
 }
 
 // maybe it should be implemented with another static server, in dev
-fn (mut app App) send_file(filname string, content string) veb.Result {
+fn (mut app App) send_file(mut ctx Context, filname string, content string) veb.Result {
 	ctx.set_header(.content_disposition, 'attachment; filename="${filname}"')
 
 	return ctx.ok(content)

--- a/src/issue_routes.v
+++ b/src/issue_routes.v
@@ -39,7 +39,7 @@ pub fn (mut app App) new_issue(username string, repo_name string) veb.Result {
 }
 
 @['/:username/issues']
-pub fn (mut app App) handle_get_user_issues(username string) veb.Result {
+pub fn (mut app App) handle_get_user_issues(mut ctx Context, username string) veb.Result {
 	return app.user_issues(username, 0)
 }
 

--- a/src/repo_routes.v
+++ b/src/repo_routes.v
@@ -9,7 +9,7 @@ import validation
 import git
 
 @['/:username/repos']
-pub fn (mut app App) user_repos(username string) veb.Result {
+pub fn (mut app App) user_repos(username string, mut ctx Context) veb.Result {
 	exists, user := app.check_username(username)
 
 	if !exists {
@@ -39,7 +39,7 @@ pub fn (mut app App) user_stars(username string) veb.Result {
 }
 
 @['/:username/:repo_name/settings']
-pub fn (mut app App) repo_settings(username string, repo_name string) veb.Result {
+pub fn (mut app App) repo_settings(username string, repo_name string, mut ctx Context) veb.Result {
 	repo := app.find_repo_by_name_and_username(repo_name, username) or {
 		return ctx.redirect_to_repository(username, repo_name)
 	}
@@ -142,10 +142,10 @@ pub fn (mut app App) handle_tree(username string, repo_name string) veb.Result {
 			return app.user_repos(username, mut ctx)
 		}
 		'issues' {
-			return app.handle_get_user_issues(username, mut ctx)
+			return app.handle_get_user_issues(mut ctx, username)
 		}
 		'settings' {
-			return app.user_settings(username)
+			return app.user_settings(mut ctx, username)
 		}
 		else {}
 	}

--- a/src/tag_routes.v
+++ b/src/tag_routes.v
@@ -4,7 +4,7 @@ import veb
 import os
 
 @['/:username/:repo_name/tag/:tag/:format']
-pub fn (mut app App) handle_download_tag_archive(username string, repo_name string, tag string, format string) veb.Result {
+pub fn (mut app App) handle_download_tag_archive(mut ctx Context,username string, repo_name string, tag string, format string) veb.Result {
 	// access checking will be implemented in another module
 	user := app.get_user_by_username(username) or { return ctx.not_found() }
 	repo := app.find_repo_by_name_and_user_id(repo_name, user.id) or { return ctx.not_found() }
@@ -22,5 +22,5 @@ pub fn (mut app App) handle_download_tag_archive(username string, repo_name stri
 
 	archive_content := os.read_file(archive_path) or { return ctx.not_found() }
 
-	return app.send_file(snapshot_name, archive_content)
+	return app.send_file(mut ctx,snapshot_name, archive_content)
 }

--- a/src/user_routes.v
+++ b/src/user_routes.v
@@ -73,7 +73,7 @@ pub fn (mut app App) user(username string) veb.Result {
 }
 
 @['/:username/settings']
-pub fn (mut app App) user_settings(username string) veb.Result {
+pub fn (mut app App) user_settings(mut ctx Context, username string) veb.Result {
 	is_users_settings := username == ctx.user.username
 
 	if !ctx.logged_in || !is_users_settings {
@@ -100,13 +100,13 @@ pub fn (mut app App) handle_update_user_settings(username string) veb.Result {
 	if is_username_empty {
 		ctx.error('New name is empty')
 
-		return app.user_settings(username)
+		return app.user_settings(mut ctx, username)
 	}
 
 	if ctx.user.namechanges_count > max_namechanges {
 		ctx.error('You can not change your username, limit reached')
 
-		return app.user_settings(username)
+		return app.user_settings(mut ctx, username)
 	}
 
 	is_username_valid := validation.is_username_valid(new_username)
@@ -114,7 +114,7 @@ pub fn (mut app App) handle_update_user_settings(username string) veb.Result {
 	if !is_username_valid {
 		ctx.error('New username is not valid')
 
-		return app.user_settings(username)
+		return app.user_settings(mut ctx, username)
 	}
 
 	is_first_namechange := ctx.user.last_namechange_time == 0
@@ -123,7 +123,7 @@ pub fn (mut app App) handle_update_user_settings(username string) veb.Result {
 	if !(is_first_namechange || can_change_usernane) {
 		ctx.error('You need to wait until you can change the name again')
 
-		return app.user_settings(username)
+		return app.user_settings(mut ctx, username)
 	}
 
 	is_new_username := new_username != username
@@ -132,7 +132,7 @@ pub fn (mut app App) handle_update_user_settings(username string) veb.Result {
 	if is_new_full_name {
 		app.change_full_name(ctx.user.id, full_name) or {
 			ctx.error('There was an error while updating the settings')
-			return app.user_settings(username)
+			return app.user_settings(mut ctx, username)
 		}
 	}
 
@@ -142,16 +142,16 @@ pub fn (mut app App) handle_update_user_settings(username string) veb.Result {
 		if user.id != 0 {
 			ctx.error('Name already exists')
 
-			return app.user_settings(username)
+			return app.user_settings(mut ctx, username)
 		}
 
 		app.change_username(ctx.user.id, new_username) or {
 			ctx.error('There was an error while updating the settings')
-			return app.user_settings(username)
+			return app.user_settings(mut ctx, username)
 		}
 		app.incement_namechanges(ctx.user.id) or {
 			ctx.error('There was an error while updating the settings')
-			return app.user_settings(username)
+			return app.user_settings(mut ctx, username)
 		}
 		app.rename_user_directory(username, new_username)
 	}


### PR DESCRIPTION
Builing Error:
```
src/repo_routes.v:89:28: error: method `repo_settings` parameter `ctx` is `mut`, so use `mut username` instead
   87 |     } else {
   88 |         ctx.error('Verification failed')
   89 |         return app.repo_settings(username, repo_name, mut ctx)
      |                                  ~~~~~~~~
   90 |     }
   91 |
src/repo_routes.v:89:28: error: cannot use `string` as `&Context` in argument 1 to `App.repo_settings`
   87 |     } else {
   88 |         ctx.error('Verification failed')
   89 |         return app.repo_settings(username, repo_name, mut ctx)
      |                                  ~~~~~~~~
   90 |     }
   91 |
src/repo_routes.v:89:53: error: `repo_settings` parameter `repo_name` is not `mut`, `mut` is not needed`
   87 |     } else {
   88 |         ctx.error('Verification failed')
   89 |         return app.repo_settings(username, repo_name, mut ctx)
      |                                                           ~~~
   90 |     }
   91 |
src/repo_routes.v:89:53: error: cannot use `&Context` as `string` in argument 3 to `App.repo_settings`
   87 |     } else {
   88 |         ctx.error('Verification failed')
   89 |         return app.repo_settings(username, repo_name, mut ctx)
      |                                                           ~~~
   90 |     }
   91 |
src/repo_routes.v:109:29: error: method `repo_settings` parameter `ctx` is `mut`, so use `mut username` instead
  107 |         dest_user := app.get_user_by_username(dest) or {
  108 |             ctx.error('Unknown user ${dest}')
  109 |             return app.repo_settings(username, repo_name, mut ctx)
      |                                      ~~~~~~~~
  110 |         }
  111 |
src/repo_routes.v:109:29: error: cannot use `string` as `&Context` in argument 1 to `App.repo_settings`
  107 |         dest_user := app.get_user_by_username(dest) or {
  108 |             ctx.error('Unknown user ${dest}')
  109 |             return app.repo_settings(username, repo_name, mut ctx)
      |                                      ~~~~~~~~
  110 |         }
  111 |
src/repo_routes.v:109:54: error: `repo_settings` parameter `repo_name` is not `mut`, `mut` is not needed`
  107 |         dest_user := app.get_user_by_username(dest) or {
  108 |             ctx.error('Unknown user ${dest}')
  109 |             return app.repo_settings(username, repo_name, mut ctx)
      |                                                               ~~~
  110 |         }
  111 |
src/repo_routes.v:109:54: error: cannot use `&Context` as `string` in argument 3 to `App.repo_settings`
  107 |         dest_user := app.get_user_by_username(dest) or {
  108 |             ctx.error('Unknown user ${dest}')
  109 |             return app.repo_settings(username, repo_name, mut ctx)
      |                                                               ~~~
  110 |         }
  111 |
src/repo_routes.v:114:29: error: method `repo_settings` parameter `ctx` is `mut`, so use `mut username` instead
  112 |         if app.user_has_repo(dest_user.id, repo.name) {
  113 |             ctx.error('User already owns repo ${repo.name}')
  114 |             return app.repo_settings(username, repo_name, mut ctx)
      |                                      ~~~~~~~~
  115 |         }
  116 |
src/repo_routes.v:114:29: error: cannot use `string` as `&Context` in argument 1 to `App.repo_settings`
  112 |         if app.user_has_repo(dest_user.id, repo.name) {
  113 |             ctx.error('User already owns repo ${repo.name}')
  114 |             return app.repo_settings(username, repo_name, mut ctx)
      |                                      ~~~~~~~~
  115 |         }
  116 |
src/repo_routes.v:114:54: error: `repo_settings` parameter `repo_name` is not `mut`, `mut` is not needed`
  112 |         if app.user_has_repo(dest_user.id, repo.name) {
  113 |             ctx.error('User already owns repo ${repo.name}')
  114 |             return app.repo_settings(username, repo_name, mut ctx)
      |                                                               ~~~
  115 |         }
  116 |
src/repo_routes.v:114:54: error: cannot use `&Context` as `string` in argument 3 to `App.repo_settings`
  112 |         if app.user_has_repo(dest_user.id, repo.name) {
  113 |             ctx.error('User already owns repo ${repo.name}')
  114 |             return app.repo_settings(username, repo_name, mut ctx)
      |                                                               ~~~
  115 |         }
  116 |
src/repo_routes.v:119:29: error: method `repo_settings` parameter `ctx` is `mut`, so use `mut username` instead
  117 |         if app.get_count_user_repos(dest_user.id) >= max_user_repos {
  118 |             ctx.error('User already reached the repo limit')
  119 |             return app.repo_settings(username, repo_name, mut ctx)
      |                                      ~~~~~~~~
  120 |         }
  121 |
src/repo_routes.v:119:29: error: cannot use `string` as `&Context` in argument 1 to `App.repo_settings`
  117 |         if app.get_count_user_repos(dest_user.id) >= max_user_repos {
  118 |             ctx.error('User already reached the repo limit')
  119 |             return app.repo_settings(username, repo_name, mut ctx)
      |                                      ~~~~~~~~
  120 |         }
  121 |
src/repo_routes.v:119:54: error: `repo_settings` parameter `repo_name` is not `mut`, `mut` is not needed`
  117 |         if app.get_count_user_repos(dest_user.id) >= max_user_repos {
  118 |             ctx.error('User already reached the repo limit')
  119 |             return app.repo_settings(username, repo_name, mut ctx)
      |                                                               ~~~
  120 |         }
  121 |
src/repo_routes.v:119:54: error: cannot use `&Context` as `string` in argument 3 to `App.repo_settings`
  117 |         if app.get_count_user_repos(dest_user.id) >= max_user_repos {
  118 |             ctx.error('User already reached the repo limit')
  119 |             return app.repo_settings(username, repo_name, mut ctx)
      |                                                               ~~~
  120 |         }
  121 |
src/repo_routes.v:124:29: error: method `repo_settings` parameter `ctx` is `mut`, so use `mut username` instead
  122 |         app.move_repo_to_user(repo.id, dest_user.id, dest_user.username) or {
  123 |             ctx.error('There was an error while moving the repo')
  124 |             return app.repo_settings(username, repo_name, mut ctx)
      |                                      ~~~~~~~~
  125 |         }
  126 |
src/repo_routes.v:124:29: error: cannot use `string` as `&Context` in argument 1 to `App.repo_settings`
  122 |         app.move_repo_to_user(repo.id, dest_user.id, dest_user.username) or {
  123 |             ctx.error('There was an error while moving the repo')
  124 |             return app.repo_settings(username, repo_name, mut ctx)
      |                                      ~~~~~~~~
  125 |         }
  126 |
src/repo_routes.v:124:54: error: `repo_settings` parameter `repo_name` is not `mut`, `mut` is not needed`
  122 |         app.move_repo_to_user(repo.id, dest_user.id, dest_user.username) or {
  123 |             ctx.error('There was an error while moving the repo')
  124 |             return app.repo_settings(username, repo_name, mut ctx)
      |                                                               ~~~
  125 |         }
  126 |
src/repo_routes.v:124:54: error: cannot use `&Context` as `string` in argument 3 to `App.repo_settings`
  122 |         app.move_repo_to_user(repo.id, dest_user.id, dest_user.username) or {
  123 |             ctx.error('There was an error while moving the repo')
  124 |             return app.repo_settings(username, repo_name, mut ctx)
      |                                                               ~~~
  125 |         }
  126 |
src/repo_routes.v:131:28: error: method `repo_settings` parameter `ctx` is `mut`, so use `mut username` instead
  129 |         ctx.error('Verification failed')
  130 |
  131 |         return app.repo_settings(username, repo_name, mut ctx)
      |                                  ~~~~~~~~
  132 |     }
  133 |
src/repo_routes.v:131:28: error: cannot use `string` as `&Context` in argument 1 to `App.repo_settings`
  129 |         ctx.error('Verification failed')
  130 |
  131 |         return app.repo_settings(username, repo_name, mut ctx)
      |                                  ~~~~~~~~
  132 |     }
  133 |
src/repo_routes.v:131:53: error: `repo_settings` parameter `repo_name` is not `mut`, `mut` is not needed`
  129 |         ctx.error('Verification failed')
  130 |
  131 |         return app.repo_settings(username, repo_name, mut ctx)
      |                                                           ~~~
  132 |     }
  133 |
src/repo_routes.v:131:53: error: cannot use `&Context` as `string` in argument 3 to `App.repo_settings`
  129 |         ctx.error('Verification failed')
  130 |
  131 |         return app.repo_settings(username, repo_name, mut ctx)
      |                                                           ~~~
  132 |     }
  133 |
src/repo_routes.v:142:26: error: method `user_repos` parameter `ctx` is `mut`, so use `mut username` instead
  140 |     match repo_name {
  141 |         'repos' {
  142 |             return app.user_repos(username, mut ctx)
      |                                   ~~~~~~~~
  143 |         }
  144 |         'issues' {
src/repo_routes.v:142:26: error: cannot use `string` as `&Context` in argument 1 to `App.user_repos`
  140 |     match repo_name {
  141 |         'repos' {
  142 |             return app.user_repos(username, mut ctx)
      |                                   ~~~~~~~~
  143 |         }
  144 |         'issues' {
src/repo_routes.v:142:40: error: `user_repos` parameter `username` is not `mut`, `mut` is not needed`
  140 |     match repo_name {
  141 |         'repos' {
  142 |             return app.user_repos(username, mut ctx)
      |                                                 ~~~
  143 |         }
  144 |         'issues' {
src/repo_routes.v:142:40: error: cannot use `&Context` as `string` in argument 2 to `App.user_repos`
  140 |     match repo_name {
  141 |         'repos' {
  142 |             return app.user_repos(username, mut ctx)
      |                                                 ~~~
  143 |         }
  144 |         'issues' {
src/repo_routes.v:145:38: error: method `handle_get_user_issues` parameter `ctx` is `mut`, so use `mut username` instead
  143 |         }
  144 |         'issues' {
  145 |             return app.handle_get_user_issues(username, mut ctx)
      |                                               ~~~~~~~~
  146 |         }
  147 |         'settings' {
src/repo_routes.v:145:38: error: cannot use `string` as `&Context` in argument 1 to `App.handle_get_user_issues`
  143 |         }
  144 |         'issues' {
  145 |             return app.handle_get_user_issues(username, mut ctx)
      |                                               ~~~~~~~~
  146 |         }
  147 |         'settings' {
src/repo_routes.v:145:52: error: `handle_get_user_issues` parameter `username` is not `mut`, `mut` is not needed`
  143 |         }
  144 |         'issues' {
  145 |             return app.handle_get_user_issues(username, mut ctx)
      |                                                             ~~~
  146 |         }
  147 |         'settings' {
src/repo_routes.v:145:52: error: cannot use `&Context` as `string` in argument 2 to `App.handle_get_user_issues`
  143 |         }
  144 |         'issues' {
  145 |             return app.handle_get_user_issues(username, mut ctx)
      |                                                             ~~~
  146 |         }
  147 |         'settings' {
src/tag_routes.v:25:13: error: expected 3 arguments, but got 2
   23 |     archive_content := os.read_file(archive_path) or { return ctx.not_found() }
   24 |
   25 |     return app.send_file(snapshot_name, archive_content)
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   26 | }
Details: have (string, string)
         want (&main.Context, string, string)
src/user_routes.v:103:14: error: expected 2 arguments, but got 1
  101 |         ctx.error('New name is empty')
  102 |
  103 |         return app.user_settings(username)
      |                    ~~~~~~~~~~~~~~~~~~~~~~~
  104 |     }
  105 |
Details: have (string)
         want (&main.Context, string)
src/user_routes.v:109:14: error: expected 2 arguments, but got 1
  107 |         ctx.error('You can not change your username, limit reached')
  108 |
  109 |         return app.user_settings(username)
      |                    ~~~~~~~~~~~~~~~~~~~~~~~
  110 |     }
  111 |
Details: have (string)
         want (&main.Context, string)
src/user_routes.v:117:14: error: expected 2 arguments, but got 1
  115 |         ctx.error('New username is not valid')
  116 |
  117 |         return app.user_settings(username)
      |                    ~~~~~~~~~~~~~~~~~~~~~~~
  118 |     }
  119 |
Details: have (string)
         want (&main.Context, string)
src/user_routes.v:126:14: error: expected 2 arguments, but got 1
  124 |         ctx.error('You need to wait until you can change the name again')
  125 |
  126 |         return app.user_settings(username)
      |                    ~~~~~~~~~~~~~~~~~~~~~~~
  127 |     }
  128 |
Details: have (string)
         want (&main.Context, string)
src/user_routes.v:135:15: error: expected 2 arguments, but got 1
  133 |         app.change_full_name(ctx.user.id, full_name) or {
  134 |             ctx.error('There was an error while updating the settings')
  135 |             return app.user_settings(username)
      |                        ~~~~~~~~~~~~~~~~~~~~~~~
  136 |         }
  137 |     }
Details: have (string)
         want (&main.Context, string)
src/user_routes.v:145:15: error: expected 2 arguments, but got 1
  143 |             ctx.error('Name already exists')
  144 |
  145 |             return app.user_settings(username)
      |                        ~~~~~~~~~~~~~~~~~~~~~~~
  146 |         }
  147 |
Details: have (string)
         want (&main.Context, string)
src/user_routes.v:150:15: error: expected 2 arguments, but got 1
  148 |         app.change_username(ctx.user.id, new_username) or {
  149 |             ctx.error('There was an error while updating the settings')
  150 |             return app.user_settings(username)
      |                        ~~~~~~~~~~~~~~~~~~~~~~~
  151 |         }
  152 |         app.incement_namechanges(ctx.user.id) or {
Details: have (string)
         want (&main.Context, string)
src/user_routes.v:154:15: error: expected 2 arguments, but got 1
  152 |         app.incement_namechanges(ctx.user.id) or {
  153 |             ctx.error('There was an error while updating the settings')
  154 |             return app.user_settings(username)
      |                        ~~~~~~~~~~~~~~~~~~~~~~~
  155 |         }
  156 |         app.rename_user_directory(username, new_username)
Details: have (string)
         want (&main.Context, string)
```