### PR TITLE
fix: consider other common license files present in projects

### DIFF
--- a/src/repo.v
+++ b/src/repo.v
@@ -832,7 +832,11 @@ fn find_readme_file(items []File) ?File {
 }
 
 fn find_license_file(items []File) ?File {
-	files := items.filter(it.name.to_lower() == 'license')
+	// List of common license file names
+	license_common_files := ['license', 'license.md', 'license.txt', 'licence', 'licence.md', 'licence.txt']
+
+	files := items.filter(license_common_files.contains(it.name.to_lower()))
+
 	if files.len == 0 {
 		return none
 	}

--- a/src/repo_routes.v
+++ b/src/repo_routes.v
@@ -418,7 +418,7 @@ pub fn (mut app App) tree(mut ctx Context, username string, repo_name string, br
 
 	license_file := find_license_file(items) or { File{} }
 	mut license_file_path := ''
-	println(license_file)
+
 	if license_file.id != 0 {
 		license_file_path = '/${username}/${repo_name}/blob/${branch_name}/${license_file.name}'
 	}

--- a/src/repo_routes.v
+++ b/src/repo_routes.v
@@ -418,9 +418,9 @@ pub fn (mut app App) tree(mut ctx Context, username string, repo_name string, br
 
 	license_file := find_license_file(items) or { File{} }
 	mut license_file_path := ''
-
+	println(license_file)
 	if license_file.id != 0 {
-		license_file_path = '/${username}/${repo_name}/blob/${branch_name}/LICENSE'
+		license_file_path = '/${username}/${repo_name}/blob/${branch_name}/${license_file.name}'
 	}
 
 	watcher_count := app.get_count_repo_watchers(repo_id)


### PR DESCRIPTION
```txt
/License
/License.md
/License.txt
```

are common paths used in projects. Code now considers any of them.

Also, use the file name to build the URL `license_file_path = '/${username}/${repo_name}/blob/${branch_name}/${license_file.name}'`