### PR TITLE
fix: adjust links to v hosted on gitly

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -160,9 +160,9 @@
 			<div class="block">
 				%index_check_action
 
-				<a href="/alex/v">gitly.org/vlang/v</a>
+				<a href="/medvednikov/v">gitly.org/vlang/v</a>
 
-				<a href="/alex/v">
+				<a href="/medvednikov/v">
 					<img class="gitly-screenshot" src="https://user-images.githubusercontent.com/687996/85933714-b195fe80-b8da-11ea-9ddd-09cadc2103e4.png">
 				</a>
 			</div>


### PR DESCRIPTION
Fixes the 404 not found part of: #284
(I was able to register just now with no problems)